### PR TITLE
add equals fonction in Point

### DIFF
--- a/include/rhoban_geometry/point.h
+++ b/include/rhoban_geometry/point.h
@@ -59,7 +59,11 @@ public:
                              double thetaMin =   0.0,
                              double thetaMax = 360.0);
 
+  bool equals(const Point & other , double precision = FLOAT_PRECISION) const;
   bool operator==(const Point & other) const;
+
+private:
+  constexpr static const double FLOAT_PRECISION = 0.001;
 };
 
 

--- a/src/rhoban_geometry/point.cpp
+++ b/src/rhoban_geometry/point.cpp
@@ -125,6 +125,16 @@ Point& Point::operator/=(double ratio)
   return *this;
 }
 
+
+bool Point::equals(const Point &other, double precision) const
+{
+    bool sameX = std::fabs(getX()- other.getX()) <= precision;
+    bool sameY = std::fabs(getY()- other.getY()) <= precision;
+
+    return sameX && sameY;
+}
+
+
 bool Point::operator==(const Point & other) const{
   bool sameX = getX() == other.getX();
   bool sameY = getY() == other.getY();


### PR DESCRIPTION
Problème avec l'opérateur == 
Si on prend l'exemple suivant pour tester l'égalité de deux points A et B:
A = {89.99987612, 15.00}
B = {90.00, 15.00}
if ( A == B ) {
   .....
}
renvoie faux, on ne passera jamais dans les accolades alors que l'on peut considérer que A et B sont bien égaux en arrondissant à une précision de 10 puissance -3.

Avec l'ajout de la méthode equals, on peut faire (en reprenant A et B) :
if ( A.equals(B) ){
    //precision de 0.001 par défaut 
}
ou encore
if ( A.equals(B, 0.0000001) ){ 
     //precision de 0.0000001 définie par l'utilisateur
}
